### PR TITLE
Add functionality to create cards from text files

### DIFF
--- a/cards.txt
+++ b/cards.txt
@@ -1,0 +1,4 @@
+What is 5 + 5?,10,STEM
+What is Rachel's favorite animal?,red panda,Turing Staff
+What is Mike's middle name?,nobody knows,Turing Staff
+What cardboard cutout lives at Turing?,Justin bieber,PopCulture

--- a/flashcard_runner.rb
+++ b/flashcard_runner.rb
@@ -2,17 +2,9 @@ require './lib/card'
 require './lib/deck'
 require './lib/turn'
 require './lib/round'
+require './lib/card_generator'
 
-deck = Deck.new(
-                [
-                  Card.new("What is a group of jelly fish called?", "Smack", :Animals),
-                  Card.new("Polar Bears mainly feed on what animals?", "Seals", :Animals),
-                  Card.new("How many digits of pi are there?", "Infinity", :Math),
-                  Card.new("What is the largest internal organ of the human body?", "Liver", :Anatomy),
-                  Card.new("Which bone is the longest bone in the human body?", "Femur", :Anatomy),
-                  Card.new("Whats the world's largest ocean?", "Pacific", :Geography),
-                  Card.new("What is the largest animal on Earth?", "Blue Whale", :Animals),
-                ]
-              )
-round = Round.new(deck)
+filename = "cards.txt"
+cards = CardGenerator.new(filename).cards
+round = Round.new(cards)
 round.start

--- a/lib/card_generator.rb
+++ b/lib/card_generator.rb
@@ -1,0 +1,5 @@
+class CardGenerator
+  def initialize(filename)
+    @file = filename
+  end
+end

--- a/lib/card_generator.rb
+++ b/lib/card_generator.rb
@@ -1,11 +1,23 @@
 class CardGenerator
+  attr_reader :deck
+
   def initialize(filename)
     @filename = filename
-    @cards = []
+    @card_data = []
+    @deck = Deck.new([])
   end
 
   def process_cards_file
-    cards_data = File.open(@filename)
-    @cards = cards_data.readlines.map(&:chomp)
+    card_data = File.open(@filename)
+    @card_data = card_data.readlines.map(&:chomp)
+  end
+
+  def cards
+    process_cards_file
+    @card_data.each do |card|
+      card = card.split(',')
+      @deck.cards << Card.new(card[0], card[1], card[2])
+    end
+    @deck
   end
 end

--- a/lib/card_generator.rb
+++ b/lib/card_generator.rb
@@ -1,3 +1,6 @@
+require './lib/deck'
+require './lib/card'
+
 class CardGenerator
   attr_reader :deck
 

--- a/lib/card_generator.rb
+++ b/lib/card_generator.rb
@@ -1,5 +1,11 @@
 class CardGenerator
   def initialize(filename)
-    @file = filename
+    @filename = filename
+    @cards = []
+  end
+
+  def process_cards_file
+    cards_data = File.open(@filename)
+    @cards = cards_data.readlines.map(&:chomp)
   end
 end

--- a/lib/round.rb
+++ b/lib/round.rb
@@ -54,11 +54,11 @@ class Round
   end
 
   def percent_correct
-    (@number_correct.to_f / @turns.length.to_f) * 100
+    (@number_correct.to_f / @turns.size.to_f) * 100
   end
 
   def percent_correct_by_category(category)
-    (number_correct_by_category(category).to_f / turns_by_category(category).length.to_f) * 100
+    (number_correct_by_category(category).to_f / turns_by_category(category).size.to_f) * 100
   end
 
   def group_turns_by_category
@@ -68,9 +68,9 @@ class Round
   end
 
   def start
-    puts "Welcome! You're playing with #{@deck.cards.length} cards."
+    puts "Welcome! You're playing with #{@deck.count} cards."
     puts "-------------------------------------------------"
-    puts "This is card number #{@turns.length + 1} out of #{@deck.cards.length}."
+    puts "This is card number #{@turns.size + 1} out of #{@deck.count}."
     puts "\nQuestion:  #{current_card.question}"
     print ">> "
     guess = gets.chomp
@@ -84,9 +84,9 @@ class Round
   end
 
   def next_card
-    until @turns.length == @deck.cards.length
-      print "This is card number #{@turns.length + 1}"
-      puts " out of #{@deck.cards.length}.\n\n"
+    until @turns.size == @deck.count
+      print "This is card number #{@turns.size + 1}"
+      puts " out of #{@deck.count}.\n\n"
       puts "Question:  #{current_card.question}"
       print ">> "
       guess = gets.chomp
@@ -103,8 +103,12 @@ class Round
   def print_results
     correct_ratio = percent_correct.round
     puts "****** Game over! ******"
-    print "You had #{@number_correct} correct guesses out"
-    puts " of #{@deck.cards.length} for a total score of #{correct_ratio}%."
+    if @number_correct == 1
+      print "You had 1 correct guess out"
+    else
+      print "You had #{@number_correct} correct guesses out"
+    end
+    puts " of #{@deck.count} for a total score of #{correct_ratio}%."
     category_hash = group_turns_by_category
     category_hash.each do |category, turn|
       result = percent_correct_by_category(category)

--- a/lib/round.rb
+++ b/lib/round.rb
@@ -19,10 +19,10 @@ class Round
 
   def take_turn(guess)
     @turn = Turn.new(guess, current_card)
-    @turns << turn
-    process_guess(turn)
+    @turns << @turn
+    process_guess(@turn)
     @deck.cards.rotate!
-    return turn
+    return @turn
   end
 
   def process_guess(turn)

--- a/test/card_generator_test.rb
+++ b/test/card_generator_test.rb
@@ -1,11 +1,26 @@
 require 'minitest/autorun'
 require 'minitest/pride'
 require './lib/card_generator'
+require './lib/turn'
+require './lib/card'
+require './lib/deck'
+require './lib/round'
 
 class CardGeneratorTest < Minitest::Test
   def test_it_exists
     filename = "cards.txt"
     cards = CardGenerator.new(filename)
     assert_instance_of CardGenerator, cards
+  end
+
+  def test_it_can_create_array_of_strings_from_file_data
+    filename = "cards.txt"
+    cards = CardGenerator.new(filename)
+    assert_equal [
+                   "What is 5 + 5?,10,STEM",
+                   "What is Rachel's favorite animal?,red panda,Turing Staff",
+                   "What is Mike's middle name?,nobody knows,Turing Staff",
+                   "What cardboard cutout lives at Turing?,Justin bieber,PopCulture"
+                 ], cards.process_cards_file
   end
 end

--- a/test/card_generator_test.rb
+++ b/test/card_generator_test.rb
@@ -23,7 +23,7 @@ class CardGeneratorTest < Minitest::Test
                  ], cards.process_cards_file
   end
 
-  def test_card_gen_cards_method_can_create_a_deck_from_text_file
+  def test_card_gen_cards_method_can_create_a_deck_of_cards_from_text_file
     filename = "cards.txt"
     cards = CardGenerator.new(filename)
     cards.cards

--- a/test/card_generator_test.rb
+++ b/test/card_generator_test.rb
@@ -1,0 +1,10 @@
+require 'minitest/autorun'
+require 'minitest/pride'
+require './lib/card_generator'
+
+class CardGeneratorTest < Minitest::Test
+  def test_it_exists
+    cards = CardGenerator.new(filename).cards
+    assert_instance_of CardGenerator, cards
+  end
+end

--- a/test/card_generator_test.rb
+++ b/test/card_generator_test.rb
@@ -1,9 +1,8 @@
 require 'minitest/autorun'
 require 'minitest/pride'
 require './lib/card_generator'
-require './lib/turn'
-require './lib/card'
 require './lib/deck'
+require './lib/card'
 require './lib/round'
 
 class CardGeneratorTest < Minitest::Test
@@ -13,7 +12,7 @@ class CardGeneratorTest < Minitest::Test
     assert_instance_of CardGenerator, cards
   end
 
-  def test_it_can_create_array_of_strings_from_file_data
+  def test_it_can_create_array_of_strings_from_card_data
     filename = "cards.txt"
     cards = CardGenerator.new(filename)
     assert_equal [
@@ -22,5 +21,14 @@ class CardGeneratorTest < Minitest::Test
                    "What is Mike's middle name?,nobody knows,Turing Staff",
                    "What cardboard cutout lives at Turing?,Justin bieber,PopCulture"
                  ], cards.process_cards_file
+  end
+
+  def test_card_gen_cards_method_can_create_a_deck_from_text_file
+    filename = "cards.txt"
+    cards = CardGenerator.new(filename)
+    cards.cards
+    assert_instance_of Deck, cards.deck
+    assert_equal 4, cards.deck.cards.length
+    assert_instance_of Card, cards.deck.cards[0]
   end
 end

--- a/test/card_generator_test.rb
+++ b/test/card_generator_test.rb
@@ -4,7 +4,8 @@ require './lib/card_generator'
 
 class CardGeneratorTest < Minitest::Test
   def test_it_exists
-    cards = CardGenerator.new(filename).cards
+    filename = "cards.txt"
+    cards = CardGenerator.new(filename)
     assert_instance_of CardGenerator, cards
   end
 end

--- a/test/round_test.rb
+++ b/test/round_test.rb
@@ -4,6 +4,7 @@ require './lib/turn'
 require './lib/card'
 require './lib/deck'
 require './lib/round'
+require './lib/card_generator'
 
 class RoundTest < Minitest::Test
 
@@ -159,5 +160,14 @@ class RoundTest < Minitest::Test
     second_turn = round.take_turn("Venus")
     assert_instance_of Hash, round.group_turns_by_category
     assert_equal [:Geography, :STEM], round.group_turns_by_category.keys
+  end
+
+  def test_round_can_initiate_with_deck_created_by_card_gen_object
+    filename = "cards.txt"
+    cards = CardGenerator.new(filename).cards
+    round = Round.new(cards)
+    assert_instance_of Deck, round.deck
+    assert_equal 4, round.deck.cards.length
+    assert_equal "What is 5 + 5?", round.deck.cards.first.question
   end
 end


### PR DESCRIPTION
- Add CardGenerator class & tests that instantiates a Deck of Cards & completes iteration 4. I set the generator up slightly different than the spec to create an array of Card objects because I was having trouble with nested arrays. My program takes the extra step of instantiating a round-ready deck from cards.txt, which I like since the `round.start()` method expects a Deck object. It works well for starting a round with one text file but would need to be iterated on if there were a desire to build a deck from multiple text files.
- Confirmed all tests are passing
- Cleaned up a few messy bits of code